### PR TITLE
[FEAT] 스키마 옵션 선택 UI 및 필드 숨김 처리

### DIFF
--- a/src/schema/members.ts
+++ b/src/schema/members.ts
@@ -41,6 +41,7 @@ const Members = buildCollection<TMembers>({
       description: '',
       validation: { required: true },
       dataType: 'string',
+      disabled: { hidden: true },
     },
     order: {
       name: '순서',
@@ -200,6 +201,10 @@ const Members = buildCollection<TMembers>({
       description: '',
       validation: { required: true },
       dataType: 'string',
+      enumValues: {
+        ko: 'ko',
+        en: 'en',
+      },
     },
   },
 });

--- a/src/schema/news.ts
+++ b/src/schema/news.ts
@@ -26,6 +26,7 @@ const News = buildCollection<TNews>({
       description: '',
       validation: { required: false },
       dataType: 'string',
+      disabled: { hidden: true },
     },
     title: {
       name: '제목',
@@ -44,6 +45,10 @@ const News = buildCollection<TNews>({
       description: '',
       validation: { required: true },
       dataType: 'string',
+      enumValues: {
+        media: 'media',
+        recent: 'recent',
+      },
     },
     agency: {
       name: '기관',

--- a/src/schema/work.ts
+++ b/src/schema/work.ts
@@ -90,6 +90,10 @@ const Work = buildCollection<TWork>({
       description: '',
       validation: { required: true },
       dataType: 'string',
+      enumValues: {
+        ko: 'ko',
+        en: 'en',
+      },
     },
     categoryId: {
       name: '카테고리아이디',


### PR DESCRIPTION
## 변경 사항

FireCMS 스키마의 폼 UI를 개선합니다.

| # | 항목 | 파일 | 변경 |
|---|------|------|------|
| 1 | 뉴스 타입(media/recent) | `src/schema/news.ts` | `enumValues` 선택 UI로 변경 |
| 2 | 뉴스 objectID | `src/schema/news.ts` | `disabled: { hidden: true }` 숨김 |
| 3 | 언어(ko/en) | `src/schema/members.ts`, `src/schema/work.ts` | `enumValues` 선택 UI로 변경 |
| 4 | 멤버 유니크아이디 | `src/schema/members.ts` | `disabled: { hidden: true }` 숨김 |

## 참고
- 언어 필드는 members/work 두 스키마에 동일하게 있어 일관성을 위해 둘 다 select로 변경했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)